### PR TITLE
fix(interceptor): :bug: handle token refresh and retry requests corre…

### DIFF
--- a/src/app/core/services/authentication/authentication.service.ts
+++ b/src/app/core/services/authentication/authentication.service.ts
@@ -74,7 +74,7 @@ export class AuthenticationService {
 						_userCredential as UserCredential
 					);
 
-					this._storageService.setItem<UserCredential>(
+					this._storageService.setItem<string>(
 						FirebaseStorage.ACCESS_TOKEN,
 						_userCredential.user.accessToken ?? ''
 					);

--- a/src/app/core/services/authentication/refresh.token.service.ts
+++ b/src/app/core/services/authentication/refresh.token.service.ts
@@ -1,43 +1,16 @@
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { UserCredential } from '@angular/fire/auth';
-import { of } from 'rxjs';
-import { Observable } from 'rxjs/internal/Observable';
-
-import { environment } from '../../../../environments/environment';
-import { FirebaseStorage } from '../../../common/constants/firebase.constants';
-import { StorageService } from '../storage/storage.service';
+import { Auth } from '@angular/fire/auth';
+import { from, Observable } from 'rxjs';
 
 @Injectable({
 	providedIn: 'root'
 })
 export class RefreshTokenService {
-	private readonly _storageService = inject(StorageService);
-	private readonly _http = inject(HttpClient);
+	private auth = inject(Auth);
 
-	getRefreshToken(): Observable<UserCredential | undefined> {
-		const {
-			user: { refreshToken }
-		} = this._storageService.getItem(
-			FirebaseStorage.FIREBASE_USER_CREDENTIAL
-		) as UserCredential;
-
-		const body = new HttpParams()
-			.append('refresh_token', refreshToken ?? '')
-			.append('grant_type', 'refresh_token');
-
-		if (refreshToken)
-			return this._http.post<UserCredential>(
-				`https://securetoken.googleapis.com/v1/token?key=${environment?.firebase?.apiKey}`,
-				body,
-				{
-					headers: new HttpHeaders().set(
-						'Content-Type',
-						'application/x-www-form-urlencoded'
-					)
-				}
-			);
-
-		return of(undefined);
+	verifyIdToken(): Observable<string> {
+		return from(
+			this.auth?.currentUser?.getIdToken(/* forceRefresh */ true) ?? ''
+		);
 	}
 }


### PR DESCRIPTION
handle token refresh and retry requests correctly

Refactored ApiInterceptor to handle token refresh and retry requests.
- Converted verifyIdToken to Observable.
- Updated HttpHandler and VerifyToken to chain observables and handle errors.
- Retried requests with new access token on 403 errors.